### PR TITLE
Process Heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ t1.start()
 t2.start()
 t1.join()
 t2.join()
+
+p1.stop()
+p2.stop()
 ```
 
 Whoever is last to update the record in the cache will know since `count()` will return `1`. At that point we'll know the record is finished being updated, and is ready to be written to the database. 
@@ -107,4 +110,5 @@ for user_update in user_updates:
     lru_cache.set(user_update.user_id, Update(process=p, doc=**user_update))
 
 lru_cache.expire_all()
+p.stop()
 ```

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     name='disref',
     version='0.2',
     packages=find_packages(),
-    author='Andrew Kelleher', 
-    author_email='andrew.kelleher@buzzfeed.com', 
+    author='Andrew Kelleher, Matthew Semanyshyn',
+    author_email='andrew.kelleher@buzzfeed.com, matthew.semanyshyn@buzzfeed.com',
     description='Provides easy, fault tolerant, distributed references with redis as a backend.',
     test_suite='test',
     install_requires=[

--- a/test.py
+++ b/test.py
@@ -1,9 +1,11 @@
 import unittest
 import json
 import redis
+import datetime
 from dateutil import parser
 import datetime
 import pytz
+import time
 
 from disref.reference import Reference
 from disref.process import Process
@@ -11,6 +13,10 @@ from disref.update import Update
 from disref.cache import LruCache
 
 class ProcessTest(unittest.TestCase):
+
+    def setUp(self):
+        if hasattr(Process, "client"):
+            Process.client.flushdb()
 
     def test_init_establishes_connection_once(self):
         p1 = Process()
@@ -20,13 +26,87 @@ class ProcessTest(unittest.TestCase):
         assert Process.client is p2.client
         assert p1.client is p2.client
 
-    def test_init_ignore_differing_connection_setting(self):
+        p1.stop()
+        p2.stop()
+
+    def test_init_ignores_differing_connection_setting(self):
         p1 = Process()
         p2 = Process(host="notlocalhost", port=123)
 
         p2_connection = p2.client.connection_pool.connection_kwargs
         assert p2_connection['host'] != "notlocalhost"
         assert p2_connection['port'] != 123
+
+        p1.stop()
+        p2.stop()
+
+    def test_init_create_heartbeat_data(self):
+        p = Process()
+
+        assert p.heartbeat_interval == 10
+        assert p.heartbeat_hash_name == "disref_heartbeat"
+        assert isinstance(p._Process__heartbeat_ref, Reference)
+
+        p.stop()
+
+    def test_heartbeat_updates(self):
+        p = Process(heartbeat_interval=2)
+
+        current_time = p.client.hget(p.heartbeat_hash_name, p.id)
+
+        time.sleep(3)
+
+        new_time = p.client.hget(p.heartbeat_hash_name, p.id)
+
+        assert parser.parse(new_time) >= parser.parse(current_time) + datetime.timedelta(seconds=p.heartbeat_interval)
+
+        p.stop()
+
+    def test_multiple_heartbeats_update(self):
+        p1 = Process(heartbeat_interval=2)
+        p2 = Process(heartbeat_interval=2)
+        p3 = Process(heartbeat_interval=2)
+
+        current_time_1 = p1.client.hget(p1.heartbeat_hash_name, p1.id)
+        current_time_2 = p2.client.hget(p2.heartbeat_hash_name, p2.id)
+        current_time_3 = p3.client.hget(p3.heartbeat_hash_name, p3.id)
+
+        time.sleep(3)
+
+        new_time_1 = p1.client.hget(p1.heartbeat_hash_name, p1.id)
+        new_time_2 = p2.client.hget(p2.heartbeat_hash_name, p2.id)
+        new_time_3 = p3.client.hget(p3.heartbeat_hash_name, p3.id)
+
+        assert parser.parse(new_time_1) >= parser.parse(current_time_1) + datetime.timedelta(seconds=p1.heartbeat_interval)
+        assert parser.parse(new_time_2) >= parser.parse(current_time_2) + datetime.timedelta(seconds=p2.heartbeat_interval)
+        assert parser.parse(new_time_3) >= parser.parse(current_time_3) + datetime.timedelta(seconds=p3.heartbeat_interval)
+        assert new_time_1 != new_time_2
+        assert new_time_2 != new_time_3
+
+        p1.stop()
+        p2.stop()
+        p3.stop()
+
+    def test_stop_cleans_up(self):
+        p1 = Process(heartbeat_interval=2)
+        p2 = Process(heartbeat_interval=2)
+
+        current_time_1 = p1.client.hget(p1.heartbeat_hash_name, p1.id)
+
+        assert p2._Process__heartbeat_ref.count() is 2
+        p1.stop()
+
+        time.sleep(3)
+
+        new_time_2 = p1.client.hget(p1.heartbeat_hash_name, p1.id)
+
+        assert isinstance(parser.parse(current_time_1), datetime.datetime)
+        assert new_time_2 == current_time_1
+        assert p2._Process__heartbeat_ref.count() is 1
+
+        p2.stop()
+
+        assert p2._Process__heartbeat_ref.count() is 0
 
 
 class ReferenceTest(unittest.TestCase):
@@ -45,6 +125,7 @@ class ReferenceTest(unittest.TestCase):
         assert a.reflist_key == 'disref_foo.reflist'
         assert a.resource_key == 'foo'
         assert a.times_modified_key == 'disref_foo.times_modified'
+        p.stop()
 
     def test_lock_is_non_reentrant(self):
         p = Process()
@@ -52,6 +133,7 @@ class ReferenceTest(unittest.TestCase):
 
         assert a.lock() == True
         assert a.lock(block=False) == False
+        p.stop()
 
     def test_lock_acquires_and_releases(self):
         p = Process()
@@ -60,6 +142,7 @@ class ReferenceTest(unittest.TestCase):
         assert a.lock(block=False) == False
         a.release()
         assert a.lock() == True
+        p.stop()
 
     def test_refresh_session_sets_time_initially(self):
         p = Process()
@@ -68,6 +151,7 @@ class ReferenceTest(unittest.TestCase):
         reflist = json.loads(p.client.get(a.reflist_key) or "{}")
         assert len(reflist) == 1, "{0}: {1}".format(reflist, len(reflist))
         assert isinstance(parser.parse(reflist[p.id]), datetime.datetime)
+        p.stop()
 
     def test_refresh_session_resets_time(self):
         p = Process()
@@ -80,6 +164,7 @@ class ReferenceTest(unittest.TestCase):
         assert end > start
         assert isinstance(end, datetime.datetime)
         assert isinstance(start, datetime.datetime)
+        p.stop()
 
     def test_get_and_increment_times_modified(self):
         p = Process()
@@ -94,11 +179,14 @@ class ReferenceTest(unittest.TestCase):
         b = p2.create_reference('foo')
         b.increment_times_modified()
         assert b.get_times_modified() == 4
+        p.stop()
+        p2.stop()
 
     def test_count_for_one_reference(self):
         p = Process()
         a = p.create_reference('foo')
         assert a.count() == 1
+        p.stop()
 
     def test_count_for_multiple_references(self):
         p = Process()
@@ -113,6 +201,10 @@ class ReferenceTest(unittest.TestCase):
         assert a.count() == b.count()
         assert b.count() == c.count()
         assert c.count() == 3
+        
+        p.stop()
+        p2.stop()
+        p3.stop()
 
     def test_count_decrements_when_dereferenced(self):
         p = Process()
@@ -134,6 +226,10 @@ class ReferenceTest(unittest.TestCase):
         c.dereference()
         assert a.count() == 0, Reference.client.get(a.reflist_key)
 
+        p.stop()
+        p2.stop()
+        p3.stop()
+
     def test_remove_failed_processes(self):
         now = datetime.datetime.now(pytz.utc)
         expired = now - datetime.timedelta(seconds=2 * Process.TTL + 1)
@@ -147,6 +243,8 @@ class ReferenceTest(unittest.TestCase):
         assert u'2' not in target, target
         assert u'1' in target, target
         assert target[u'1'] == now.isoformat(), target
+
+        p.stop()
 
     def test_dereference_removes_pid_from_pids(self):
         p = Process()
@@ -165,6 +263,9 @@ class ReferenceTest(unittest.TestCase):
         pids = json.loads(b._Reference__process.client.get(b.reflist_key) or "{}")
         assert b._Reference__process.id not in pids
         assert len(pids) == 0
+
+        p.stop()
+        p2.stop()
 
     def test_dereference_cleans_up(self):
         p = Process()
@@ -187,6 +288,9 @@ class ReferenceTest(unittest.TestCase):
         assert Process.client.get(a.resource_key) == None, Process.client.get(a.resource_key)
         assert Process.client.get(a.times_modified_key) == None, Process.client.get(a.times_modified_key)
 
+        p.stop()
+        p2.stop()
+
     def test_dereference_handles_when_never_modified(self):
         p = Process()
         a = p.create_reference('foo')
@@ -196,6 +300,8 @@ class ReferenceTest(unittest.TestCase):
         a.dereference()
         pids = json.loads(a._Reference__process.client.get(a.reflist_key) or "{}")
         assert len(pids) == 0, pids
+
+        p.stop()
 
     def test_dereference_calls_callback(self):
         p = Process()
@@ -212,6 +318,9 @@ class ReferenceTest(unittest.TestCase):
         assert len(foo) == 1
         a.dereference(callback, args=('second',))
         assert len(foo) == 0
+
+        p.stop()
+        p2.stop()
 
 class UpdateTest(unittest.TestCase):
 
@@ -245,13 +354,16 @@ class UpdateTest(unittest.TestCase):
             client.set("{0}.write".format(self.resource_id), json.dumps(obj))
 
     def test_initializer_updates_ref_count(self):
-        a = UpdateTest.UserUpdate(process=Process(), _id='123', database='test', collection='user',
+        p = Process()
+        a = UpdateTest.UserUpdate(process=p,  _id='123', database='test', collection='user',
                 spec={'_id': 123}, doc={'a': 1., 'b': 2., 'c': 3.})
 
         client = a._Update__process.client
         reflist = json.loads(client.get(a.ref.reflist_key) or "{}")
         assert len(reflist) == 1
         assert a._Update__process.id in reflist
+
+        p.stop()
 
     def test_cache_caches(self):
         p = Process()
@@ -315,6 +427,9 @@ class UpdateTest(unittest.TestCase):
             assert expected_doc[k] == v
         for k, v in expected_doc.items():
             assert target['doc'][k] == v
+
+        p.stop()
+        p2.stop()
 
     def test_end_session_raises_when_deadlocked(self):
         pass


### PR DESCRIPTION
Tracks the health of process instances by implementing a heartbeat.  Updates the disref_heartbeat hash with the current unix time for process at a set `heartbeat_interval`.
