### PR TITLE
Reference Registry

### DIFF
--- a/disref/process.py
+++ b/disref/process.py
@@ -2,7 +2,7 @@ import sherlock
 import redis
 import uuid
 
-from disref import get_logger
+from disref import get_logger, DISREF_NAMESPACE
 from disref.reference import Reference
 
 
@@ -50,6 +50,8 @@ class Process(object):
 
         self.client = Process.client
 
+        self.registry_key = "{0}_{1}".format(DISREF_NAMESPACE, self.id)
+
 
     def create_reference(self, resource, block=True):
         """
@@ -60,4 +62,6 @@ class Process(object):
 
         :returns: The created Reference object
         """
+
+        self.client.hset(self.registry_key, resource, 1)
         return Reference(self, resource, block)

--- a/disref/reference.py
+++ b/disref/reference.py
@@ -238,5 +238,7 @@ class Reference(object):
             if rc:
                 client.delete(self.resource_key, self.reflist_key, self.times_modified_key)
 
+        client.hdel(self.__process.registry_key, self.resource_key)
+
         return rc
 

--- a/test.py
+++ b/test.py
@@ -28,6 +28,16 @@ class ProcessTest(unittest.TestCase):
         assert p2_connection['host'] != "notlocalhost"
         assert p2_connection['port'] != 123
 
+    def test_process_registry_tracks_references(self):
+        p1 = Process()
+        a = p1.create_reference("foo")
+
+        assert p1.client.hexists(p1.registry_key, a.resource_key)
+
+        a.dereference()
+
+        assert p1.client.hexists(p1.registry_key, a.resource_key) is False
+
 
 class ReferenceTest(unittest.TestCase):
 


### PR DESCRIPTION
Creates a hash ( named disref_{{process_id}} ), which tracks all the references associated with a particular process.  
