### PR TITLE
Reference Registry

### DIFF
--- a/disref/process.py
+++ b/disref/process.py
@@ -54,12 +54,16 @@ class Process(object):
                                 .format(connection_kwargs['port'], connection_kwargs['host'], connection_kwargs['db']))
 
         self.client = Process.client
+   
+        self.registry_key = "{0}_{1}".format(DISREF_NAMESPACE, self.id)
 
         self.heartbeat_interval = heartbeat_interval
         self.heartbeat_hash_name = "{0}_heartbeat".format(DISREF_NAMESPACE)
         self.__heartbeat_ref = self.create_reference(self.heartbeat_hash_name)
         self.__heartbeat_timer = None
         self.__update_heartbeat()
+
+
 
     def create_reference(self, resource, block=True):
         """
@@ -72,6 +76,8 @@ class Process(object):
 
         :returns: The created Reference object
         """
+
+        self.client.hset(self.registry_key, resource, 1)
         return Reference(self, resource, block)
 
     def __update_heartbeat(self):

--- a/disref/reference.py
+++ b/disref/reference.py
@@ -238,5 +238,7 @@ class Reference(object):
             if rc:
                 client.delete(self.resource_key, self.reflist_key, self.times_modified_key)
 
+        client.hdel(self.__process.registry_key, self.resource_key)
+
         return rc
 

--- a/test.py
+++ b/test.py
@@ -1,8 +1,8 @@
 import unittest
 import json
 import redis
-import datetime
 from dateutil import parser
+import datetime
 import pytz
 import time
 import logging
@@ -106,6 +106,18 @@ class ProcessTest(unittest.TestCase):
         p2.stop()
 
         assert p2._Process__heartbeat_ref.count() is 0
+
+    def test_process_registry_tracks_references(self):
+        p1 = Process()
+        a = p1.create_reference("foo")
+
+        assert p1.client.hexists(p1.registry_key, a.resource_key)
+
+        a.dereference()
+
+        assert p1.client.hexists(p1.registry_key, a.resource_key) is False
+
+        p1.stop()
 
 
 class ReferenceTest(unittest.TestCase):


### PR DESCRIPTION
Creates a hash ( named disref_{{process_id}} ), which tracks all the references associated with a particular process.
