### PR TITLE
Locking Context Manager and Sherlock removal 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,24 +51,24 @@ email_verification_service = p2.create_reference(resource='me')
 def lookup_email_and_apply_to_record(record, reference):
     email = get_email(record)
     try:
-        reference.lock()
-        update_record_with_email(record, email)
-        if reference.count() == 1:
-            write_record_to_database(record)
-        reference.release()
-    except disref.AlreadyLocked, e:
-        raise Exception("Timed out acquiring lock!")
+        with email_verification_service.lock():
+            update_record_with_email(record, email)
+            if email_verification_service.count() == 1:
+                write_record_to_database(record)
+    except Process.AlreadyLocked, e:
+        # Unable to acquire lock. Handle as needed.  
+        pass
 
 def verify_address_and_apply_to_record(record, reference):
     address = get_address(record)
     try:
-        reference.lock()
-        update_record_with_address(record, address)
-        if reference.count() == 1:
-            write_record_to_database(record)
-        reference.release()
-    except disref.AlreadyLocked, e:
-        raise Exception("Timed out acquiring lock!")
+        with address_lookup_service.lock():
+            update_record_with_address(record, address)
+            if address_lookup_service.count() == 1:
+                write_record_to_database(record)
+    except Process.AlreadyLocked, e:
+        # Unable to acquire lock. Handle as needed.
+        pass
 
 t1 = threading.Thread(target=lookup_email_and_apply_to_record,
     args=('me', email_verification_service))

--- a/disref/process.py
+++ b/disref/process.py
@@ -1,10 +1,9 @@
-import sherlock
 import redis
 import uuid
 import time
 import threading
 
-from disref import get_logger, DISREF_NAMESPACE
+from disref import get_logger, DisRefError, DISREF_NAMESPACE
 from disref.reference import Reference
 
 logger = get_logger(__name__)
@@ -22,7 +21,55 @@ class Process(object):
 
     TTL = 30 * 60  # 30 minutes
     RETRY_SLEEP = 0.5    # Second
-    TIMEOUT = 500
+    BLOCKING_TIMEOUT = 500
+
+    class Lock(object):
+        def __init__(self, process, lock_key, block=True):
+            """
+            :param Process process: The Process which is issuing this lock
+            :param str lock_key: The key at which to acquire a lock
+            :param bool block: Optional. Whether or not to block when
+                establishing the lock.
+            """
+            self.block = block
+            self.lock_key = lock_key
+            self.client = process.client
+            self.__process = process
+            self.__lock = None
+
+        def __enter__(self):
+            locked = self._acquire()
+            if locked:
+                return locked
+            else:
+                raise Process.AlreadyLocked(
+                        "Could not acquire a lock. Possible deadlock for key: {0}".format(self.lock_key))
+
+        def __exit__(self, type, value, traceback):
+            self._release()
+
+        def _acquire(self, block=None):
+            """
+            Locks at the specified lock_key.
+
+            :param bool block: Whether or not to block while acquiring the lock.
+            :returns: Whether or not the lock was successfully acquired.
+            :rtype: bool
+            """
+            if self.__lock is None:
+                self.__lock = self.client.lock(name=self.lock_key, timeout=self.__process.TTL, 
+                    sleep=self.__process.RETRY_SLEEP, blocking_timeout=self.__process.BLOCKING_TIMEOUT)
+
+            self.__lock.blocking = self.block
+            return self.__lock.acquire()
+
+        def _release(self):
+            if self.__lock is None or self.__lock.local.token is None:
+                return True
+            return self.__lock.release()
+
+    class AlreadyLocked(DisRefError):
+        pass
 
     def __init__(self, session_length=int(0.5*TTL), host='localhost', port=6379, db=1, heartbeat_interval=10):
         """
@@ -34,18 +81,12 @@ class Process(object):
         :param int port: The port to connect to redis on.
         :param int heartbeat_interval: The frequency in seconds with which to
             update the heartbeat for this process.
-
-
         """
         self.id = unicode(uuid.uuid4())
         self.session_length = session_length
 
         if not hasattr(Process, 'client'):
             Process.client = redis.StrictRedis(host=host, port=port, db=db)
-            sherlock.configure(backend=sherlock.backends.REDIS,
-                               expire=self.TTL,
-                               retry_interval=self.RETRY_SLEEP,
-                               timeout=self.TIMEOUT)
         else:
             connection_kwargs = Process.client.connection_pool.connection_kwargs
             if connection_kwargs['port'] != port or connection_kwargs['host'] != host or connection_kwargs['db'] != db:
@@ -54,7 +95,7 @@ class Process(object):
                                 .format(connection_kwargs['port'], connection_kwargs['host'], connection_kwargs['db']))
 
         self.client = Process.client
-   
+
         self.registry_key = "{0}_{1}".format(DISREF_NAMESPACE, self.id)
 
         self.heartbeat_interval = heartbeat_interval
@@ -62,8 +103,6 @@ class Process(object):
         self.__heartbeat_ref = self.create_reference(self.heartbeat_hash_name)
         self.__heartbeat_timer = None
         self.__update_heartbeat()
-
-
 
     def create_reference(self, resource, block=True):
         """
@@ -80,19 +119,31 @@ class Process(object):
         self.client.hset(self.registry_key, resource, 1)
         return Reference(self, resource, block)
 
+    def lock(self, lock_key, block=True):
+        """
+        Issues a lock for a given key.
+
+        Usage:
+            with process.lock( some_key ):
+                pass
+
+        :param str lock_key: The key to lock
+        :param bool block: Optional. Whether or not to block when establishing
+            lock.
+        """
+        return Process.Lock(self, lock_key, block)
+
     def __update_heartbeat(self):
         """
-        Records the timestamp at a configurable interval to ensure the process is still alive.
+        Records the timestamp at a configurable interval to ensure the process
+        is still alive.
         """
         if self.__heartbeat_timer:
             self.__heartbeat_timer.cancel()
             self.__heartbeat_timer = None
 
-        try:
-            if self.__heartbeat_ref.lock():
-                self.client.hset(self.heartbeat_hash_name, self.id, int(time.time()))
-        finally:
-            self.__heartbeat_ref.release()
+        with self.lock(self.__heartbeat_ref.lock_key):
+            self.client.hset(self.heartbeat_hash_name, self.id, int(time.time()))
 
         self.__heartbeat_timer = threading.Timer(self.heartbeat_interval, self.__update_heartbeat)
         self.__heartbeat_timer.daemon = True
@@ -105,11 +156,8 @@ class Process(object):
         if self.__heartbeat_timer:
             self.__heartbeat_timer.cancel()
 
-        try:
-            if self.__heartbeat_ref.lock():
-                self.__heartbeat_ref.dereference()
-        finally:
-            self.__heartbeat_ref.release()
+        with self.__heartbeat_ref.lock():
+            self.__heartbeat_ref.dereference()
 
     def __del__(self):
         self.stop()

--- a/disref/update.py
+++ b/disref/update.py
@@ -60,17 +60,9 @@ class Update(object):
         used to write to redis or your database backend as efficiently as
         possible.
         """
-        try:
-            locked = False
-            if self.ref.lock(block=block):
-                locked = True
-                if not self.ref.dereference(self.__execute):
-                    self.__cache()
-            else: 
-                raise Reference.AlreadyLocked("Failed to lock on {0}.") 
-        finally:
-            if locked:
-                self.ref.release()
+        with self.ref.lock(block=block):
+            if not self.ref.dereference(self.__execute):
+                self.__cache()
 
     def __cache(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
     description='Provides easy, fault tolerant, distributed references with redis as a backend.',
     test_suite='test',
     install_requires=[
-        'sherlock==0.3.0',
         'pytz==2014.10',
     ],
     url='http://www.github.com/buzzfeed/disref',

--- a/test.py
+++ b/test.py
@@ -147,18 +147,31 @@ class ReferenceTest(unittest.TestCase):
         p = Process()
         a = p.create_reference('foo')
 
-        assert a.lock() == True
-        assert a.lock(block=False) == False
+        with a.lock():
+            try:
+                locked = False
+                with a.lock(block=False) as locked:
+                    pass
+            except:
+                assert locked is False
         p.stop()
 
     def test_lock_acquires_and_releases(self):
         p = Process()
         a = p.create_reference('foo')
-        assert a.lock() == True
-        assert a.lock(block=False) == False
-        a.release()
-        assert a.lock() == True
+        with a.lock():
+            try:
+                locked = False
+                with a.lock(block=False) as locked:
+                    pass
+            except:
+                assert locked is False
+
+        with a.lock():
+            pass
+
         p.stop()
+
 
     def test_refresh_session_sets_time_initially(self):
         p = Process()


### PR DESCRIPTION
Remove sherlock in favor of redis locks and implement locking context manager.  Locks now issue via process instead of reference.
