### PR TITLE
Fixes init_cache issue

### DIFF
--- a/phonon/process.py
+++ b/phonon/process.py
@@ -235,6 +235,9 @@ class Process(object):
                         for recovering_reference in recovering_references:
                             reference = self.create_reference(recovering_reference)
                             with reference.lock():
+                                # We increment the times modified to ensure that the data recovered
+                                # is pulled from the cache.
+                                reference.increment_times_modified()
                                 reference.remove_failed_process(failed_pid)
 
                         if self.remove_from_registry(recovering_references, failed_process_registry_key) == 0:


### PR DESCRIPTION
Fixes a bug in which records where merging with themselves on execution due to times_modified being updated prematurely when caching on initialization of an Update object.