### PR TITLE
Fixes init_cache issues.

### DIFF
--- a/phonon/process.py
+++ b/phonon/process.py
@@ -235,6 +235,9 @@ class Process(object):
                         for recovering_reference in recovering_references:
                             reference = self.create_reference(recovering_reference)
                             with reference.lock():
+                                # We increment the times modified to ensure that the data recovered
+                                # is pulled from the cache.
+                                reference.increment_times_modified()
                                 reference.remove_failed_process(failed_pid)
 
                         if self.remove_from_registry(recovering_references, failed_process_registry_key) == 0:

--- a/phonon/update.py
+++ b/phonon/update.py
@@ -55,8 +55,9 @@ class Update(object):
         self.database = database
         self.__process = process
         self.ref = self.__process.create_reference(resource=self.resource_id, block=block)
+        self.init_cache = init_cache
 
-        if init_cache:
+        if self.init_cache:
             self.__cache()
 
     def process(self):
@@ -89,7 +90,10 @@ class Update(object):
             cached = json.loads(self.__process.client.get(self.resource_id) or "{}")
             self.merge(cached)
         self.cache()
-        self.ref.increment_times_modified()
+        if not self.init_cache:
+            # If caching on init, we do not increment times_modified to prevent
+            # an update from merging with itself upon execution.
+            self.ref.increment_times_modified()
 
     def __execute(self):
         """


### PR DESCRIPTION
Fixes a bug in which records where merging with themselves on execution due to times_modified being updated prematurely when caching on initialization of an Update object.