### PR TITLE
Fix bad process instantiation due to connection error.

### DIFF
--- a/phonon/process.py
+++ b/phonon/process.py
@@ -74,6 +74,10 @@ class Process(object):
         self.id = unicode(uuid.uuid4())
         self.session_length = session_length
         self.recover_failed_processes = recover_failed_processes
+        self.heartbeat_interval = heartbeat_interval
+        self.heartbeat_hash_name = "{0}_heartbeat".format(PHONON_NAMESPACE)
+        self.__heartbeat_timer = None
+        self.__heartbeat_ref = None
 
         if not hasattr(Process, 'client'):
             Process.client = redis.StrictRedis(host=host, port=port, db=db)
@@ -85,13 +89,15 @@ class Process(object):
                                 .format(connection_kwargs['port'], connection_kwargs['host'], connection_kwargs['db']))
 
         self.client = Process.client
+        try:
+            self.client.ping()
+        except redis.exceptions.ConnectionError,e:
+            logger.error("Unable to connect to Redis: {0}".format(e))
+            return
 
         self.registry_key = self.__get_registry_key(self.id)
 
-        self.heartbeat_interval = heartbeat_interval
-        self.heartbeat_hash_name = "{0}_heartbeat".format(PHONON_NAMESPACE)
         self.__heartbeat_ref = self.create_reference(self.heartbeat_hash_name)
-        self.__heartbeat_timer = None
         self.__update_heartbeat()
 
     def create_reference(self, resource, block=True):
@@ -255,8 +261,9 @@ class Process(object):
         if self.__heartbeat_timer:
             self.__heartbeat_timer.cancel()
 
-        with self.__heartbeat_ref.lock():
-            self.__heartbeat_ref.dereference()
+        if self.__heartbeat_ref:
+            with self.__heartbeat_ref.lock():
+                self.__heartbeat_ref.dereference()
 
     def __del__(self):
         self.stop()


### PR DESCRIPTION
When establishing a connection with Redis, a connection error is not detected until the first interaction with the client.  To avoid this delay and having the real issue obfuscated by a side effect, we ping redis immediately to ensure that a connection has actually been established and that the rest of the Process can be instantiated using the connection.