### PR TITLE
Implement Nodelist

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ include =
     phonon/update.py
     phonon/reference.py
     phonon/process.py
+    phonon/nodelist.py
     phonon/__init__.py 
     phonon/cache.py
 [report]

--- a/phonon/nodelist.py
+++ b/phonon/nodelist.py
@@ -1,0 +1,126 @@
+import datetime
+
+from dateutil import parser
+
+from phonon import get_logger, PHONON_NAMESPACE, LOCAL_TZ
+
+class Nodelist(object):
+    """
+    Keeps track of the nodes currently holding a reference to a particular
+    resource by maintaining a hash in redis with the node ids and time the
+    session was last refreshed.
+    """
+
+    def __init__(self, process, resource_key):
+        """
+        :param Process process: The Process to which the instantiating
+            reference belongs
+        :param string resource_key: An identifier for the instantiating
+            reference
+        """
+        self.resource_key = resource_key
+        self.nodelist_key = "{0}_{1}.nodelist".format(PHONON_NAMESPACE, resource_key)
+        self.__process = process
+        self.refresh_session()
+
+    def refresh_session(self, node_id=None):
+        """
+        Adds or refreshes a particular node in the nodelist, attributing the
+        current time with the node_id.
+
+        :param string node_id: optional, the process id of the node whose
+        session should be refreshed
+        """
+        if not node_id:
+            node_id = self.__process.id
+        self.__process.client.hset(self.nodelist_key, node_id, datetime.datetime.now(LOCAL_TZ).isoformat())
+
+    def find_expired_nodes(self, node_ids=None):
+        """
+        Detects processes that have held a reference for longer than its
+        process_ttl without refreshing its session. This function does not
+        actually removed them from the hash. (See remove_expired_nodes.)
+
+        :param list node_ids: optional, a list of ids to check to see if they
+            have expired.  If node_ids is not passed in, all nodes in the hash
+            will be checked.
+        """
+        if node_ids:
+            nodes = zip(node_ids, [parser.parse(dt) for dt in self.__process.client.hmget(self.nodelist_key, node_ids)])
+        else:
+            nodes = self.get_all_nodes().items()
+
+        expiration_delta = datetime.timedelta(seconds=self.__process.process_ttl)
+        now = datetime.datetime.now(LOCAL_TZ)
+        return [node_id for (node_id, last_updated) in nodes if (now - last_updated) > expiration_delta]
+
+    def remove_expired_nodes(self, node_ids=None):
+        """
+        Removes all expired nodes from the nodelist.  If a set of node_ids is
+        passed in, those ids are checked to ensure they haven't been refreshed
+        prior to a lock being acquired.
+
+        Should only be run with a lock.
+
+        :param list node_ids: optional, a list of node_ids to remove.  They
+            will be verified to ensure they haven't been refreshed.
+
+        """
+        nodes = self.find_expired_nodes(node_ids)
+        if nodes:
+            self.__process.client.hdel(self.nodelist_key, *nodes)
+
+    def remove_node(self, node_id=None):
+        """
+        Removes a particular node from the nodelist.
+
+        Should only be run with a lock.
+
+        :param string node_id: optional, the process id of the node to remove
+        """
+        if not node_id:
+            node_id = self.__process.id
+
+        self.__process.client.hdel(self.nodelist_key, node_id)
+
+    def clear_nodelist(self):
+        """
+        Removes all nodes from a nodelist.
+
+        Should only be run with a lock.
+        """
+        self.__process.client.delete(self.nodelist_key)
+
+    def get_node(self, node_id=None):
+        """
+        Returns the time a particular node has been last refreshed.
+
+        :param string node_id: optional, the process id of the node to retrieve
+
+        :rtype: None, datetime
+        :returns: Returns a parsed datetime if exists, otherwise None
+        """
+        if not node_id:
+            node_id = self.__process.id
+
+        dt = self.__process.client.hget(self.nodelist_key, node_id)
+        return parser.parse(dt) if dt else None
+
+    def get_all_nodes(self):
+        """
+        Returns all nodes in the hash with the time they were last refreshed
+        as a dictionary.
+
+        :rtype: dict(string, datetime.datetime)
+        :returns: A dictionary of strings and corresponding datetime objects
+
+        """
+        nodes = self.__process.client.hgetall(self.nodelist_key)
+        return {node_id: parser.parse(dt) for (node_id, dt) in nodes.items()}
+
+    def count(self):
+        """
+        :rtype: int
+        :returns: The number of nodes in the nodelist
+        """
+        return len(self.__process.client.hgetall(self.nodelist_key))

--- a/phonon/process.py
+++ b/phonon/process.py
@@ -235,7 +235,7 @@ class Process(object):
                         for recovering_reference in recovering_references:
                             reference = self.create_reference(recovering_reference)
                             with reference.lock():
-                                reference.remove_failed_process(failed_pid)
+                                reference.nodelist.remove_node(failed_pid)
 
                         if self.remove_from_registry(recovering_references, failed_process_registry_key) == 0:
                             # No futher references to recover.
@@ -256,8 +256,7 @@ class Process(object):
             self.__heartbeat_timer.cancel()
 
         if self.__heartbeat_ref:
-            with self.__heartbeat_ref.lock():
-                self.__heartbeat_ref.dereference()
+            self.__heartbeat_ref.dereference()
 
     def __del__(self):
         self.stop()

--- a/phonon/update.py
+++ b/phonon/update.py
@@ -103,19 +103,20 @@ class Update(object):
         used to write to redis or your database backend as efficiently as
         possible.
         """
-        with self.ref.lock(block=block):
-            if not self.ref.dereference(self.__execute):
-                if self.is_expired() or self.ref.force_expiry:
-                    # If this update has expired but other active references
-                    # to the resource still exist, we force this update to
-                    # execute. We reset the time_modified_key and cached data
-                    # to prevent any other processes from executing the same
-                    # data.
+        if not self.ref.dereference(self.__execute, block=block):
+            if self.is_expired() or self.ref.force_expiry:
+                # If this update has expired but other active references
+                # to the resource still exist, we force this update to
+                # execute. We reset the time_modified_key and cached data
+                # to prevent any other processes from executing the same
+                # data.
+                with self.ref.lock(block=block):
                     self.__execute()
                     self.__process.client.delete(self.ref.resource_key)
                     self.__process.client.set(self.ref.times_modified_key, 0)
-                else:
-                    self.__cache()
+            else:
+                self.__cache()
+
 
     def __getstate__(self):
         default_state = {

--- a/test.py
+++ b/test.py
@@ -15,6 +15,7 @@ from phonon.reference import Reference
 from phonon.process import Process
 from phonon.update import Update
 from phonon.cache import LruCache
+from phonon.nodelist import Nodelist
 
 logging.disable(logging.CRITICAL)
 
@@ -178,12 +179,12 @@ class ProcessTest(unittest.TestCase):
         assert "12345" not in p1.client.hgetall(p1.heartbeat_hash_name)
 
         ref = p1.create_reference("r1")
-        ref_list = json.loads(p1.client.get(ref.reflist_key))
+        ref_list = ref.nodelist.get_all_nodes()
         assert "12345" not in ref_list
         assert p1.id in ref_list
 
         ref = p1.create_reference("r2")
-        ref_list = json.loads(p1.client.get(ref.reflist_key))
+        ref_list = ref.nodelist.get_all_nodes()
         assert "12345" not in ref_list
         assert p1.id in ref_list
 
@@ -251,6 +252,111 @@ class ProcessTest(unittest.TestCase):
         Process.BLOCKING_TIMEOUT = 500
         p1.stop()
 
+class NodelistTest(unittest.TestCase):
+
+    def setUp(self):
+        if hasattr(Process, "client"):
+            Process.client.flushdb()
+
+    def test_create_node_list(self):
+        p = Process()
+        nodelist = Nodelist(p, "key")
+        assert nodelist.nodelist_key == "phonon_key.nodelist"  
+        assert Process.client.hgetall(nodelist.nodelist_key) != {}
+
+        p.stop()
+
+    def test_refresh_session_refreshes_time(self):
+        p = Process()
+        nodelist = Nodelist(p, "key")
+        now = datetime.datetime.now(pytz.utc)
+        Process.client.hset(nodelist.nodelist_key, p.id, now)
+        nodelist.refresh_session()
+        updated_now = nodelist.get_node(p.id)
+        assert isinstance(updated_now, datetime.datetime)
+        assert updated_now != now
+        p.stop()
+
+    def test_find_expired_nodes(self):
+        now = datetime.datetime.now(pytz.utc)
+        expired = now - datetime.timedelta(seconds=2 * TTL + 1)
+
+        p = Process()
+        nodelist = Nodelist(p, "key")
+
+        Process.client.hset(nodelist.nodelist_key, '1', now.isoformat())
+        Process.client.hset(nodelist.nodelist_key, '2', expired.isoformat())
+
+        target = nodelist.find_expired_nodes()
+        assert u'2' in target, target
+        assert u'1' not in target, target
+
+        p.stop()
+
+    def test_remove_expired_nodes(self):
+        now = datetime.datetime.now(pytz.utc)
+        expired = now - datetime.timedelta(seconds=2 * TTL + 1)
+
+        p = Process()
+        nodelist = Nodelist(p, "key")
+
+        Process.client.hset(nodelist.nodelist_key, '1', expired.isoformat())
+        Process.client.hset(nodelist.nodelist_key, '2', expired.isoformat())
+
+        nodes = nodelist.get_all_nodes()
+        assert '1' in nodes
+        assert '2' in nodes
+
+        nodelist.remove_expired_nodes()
+        nodes = nodelist.get_all_nodes()
+        assert '1' not in nodes
+        assert '2' not in nodes
+
+        p.stop()
+
+    def test_refreshed_node_not_deleted(self):
+        now = datetime.datetime.now(pytz.utc)
+        expired = now - datetime.timedelta(seconds=2 * TTL + 1)
+
+        p = Process()
+        nodelist = Nodelist(p, 'key')
+
+        Process.client.hset(nodelist.nodelist_key, '1', expired.isoformat())
+        Process.client.hset(nodelist.nodelist_key, '2', expired.isoformat())
+
+        expired = nodelist.find_expired_nodes()
+        assert u'2' in expired, expired
+        assert u'1' in expired, expired
+        Process.client.hset(nodelist.nodelist_key, '1', now.isoformat())
+
+        nodelist.refresh_session('1')
+        nodelist.remove_expired_nodes(expired)
+
+        assert nodelist.get_node('1') is not None, nodelist.get_node('1')
+        assert nodelist.get_node('2') is None, nodelist.get_node('2')
+
+        p.stop()
+
+    def test_remove_node(self):
+        p = Process()
+        nodelist = Nodelist(p, 'key')
+        nodelist.refresh_session('1')
+
+        nodes = nodelist.get_all_nodes()
+        assert '1' in nodes
+
+        nodelist.remove_node('1')
+        nodes = nodelist.get_all_nodes()
+        assert '1' not in nodes
+        p.stop()
+
+    def test_clear_nodelist(self):
+        p = Process()
+        nodelist = Nodelist(p, 'key')
+        nodes = nodelist.clear_nodelist()
+        nodes = nodelist.get_all_nodes()
+        assert nodes == {}
+        p.stop()
 
 class ReferenceTest(unittest.TestCase):
 
@@ -265,7 +371,7 @@ class ReferenceTest(unittest.TestCase):
     def test_init_creates_keys(self):
         p = Process()
         a = p.create_reference('foo')
-        assert a.reflist_key == 'phonon_foo.reflist'
+        assert a.nodelist.nodelist_key == 'phonon_foo.nodelist'
         assert a.resource_key == 'foo'
         assert a.times_modified_key == 'phonon_foo.times_modified'
         p.stop()
@@ -299,23 +405,68 @@ class ReferenceTest(unittest.TestCase):
 
         p.stop()
 
+    def test_nodelist_updates_multinodes(self):
+        p1 = Process()
+        p2 = Process()
+        p3 = Process()
+
+        import threading
+        t = threading.Thread(target=p1.create_reference, args=('foo',))
+        t2 = threading.Thread(target=p2.create_reference, args=('foo',))
+
+        t.start()
+        t2.start()
+        a = p3.create_reference("foo")
+
+        t.join()
+        t2.join()
+
+        nodes = a.nodelist.get_all_nodes()
+        assert p1.id in nodes
+        assert p2.id in nodes
+
+        p1.stop()
+        p2.stop()
+        p3.stop()
+
+    def test_nodelist_dereferences_multinodes(self):
+        p1 = Process()
+        p2 = Process()
+
+        a = p1.create_reference('foo')
+        b = p2.create_reference('foo')
+
+        import threading
+        t = threading.Thread(target=a.dereference)
+        t2 = threading.Thread(target=b.dereference)
+
+        t.start()
+        t2.start()
+
+        t.join()
+        t2.join()
+
+        nodes = a.nodelist.get_all_nodes()
+        assert nodes == {}
+
+        p1.stop()
+        p2.stop()
+
     def test_refresh_session_sets_time_initially(self):
         p = Process()
         a = p.create_reference('foo')
         a.refresh_session()
-        reflist = json.loads(p.client.get(a.reflist_key) or "{}")
-        assert len(reflist) == 1, "{0}: {1}".format(reflist, len(reflist))
-        assert isinstance(parser.parse(reflist[p.id]), datetime.datetime)
+        nodes = a.nodelist.get_all_nodes()
+        assert a.nodelist.count() == 1, "{0}: {1}".format(nodes, len(nodes))
+        assert isinstance(a.nodelist.get_node(p.id), datetime.datetime)
         p.stop()
 
     def test_refresh_session_resets_time(self):
         p = Process()
         a = p.create_reference('foo')
-        reflist = json.loads(p.client.get(a.reflist_key) or "{}")
-        start = parser.parse(reflist[p.id])
+        start = a.nodelist.get_node(p.id)
         a.refresh_session()
-        reflist = json.loads(p.client.get(a.reflist_key) or "{}")
-        end = parser.parse(reflist[p.id])
+        end = a.nodelist.get_node(p.id)
         assert end > start
         assert isinstance(end, datetime.datetime)
         assert isinstance(start, datetime.datetime)
@@ -373,33 +524,17 @@ class ReferenceTest(unittest.TestCase):
 
         assert a.count() == b.count()
         assert b.count() == c.count()
-        assert c.count() == 3
+        assert c.count() == 3, c.count()
         a.dereference()
-        assert a.count() == 2
+        assert a.count() == 2, b.count()
         b.dereference()
-        assert a.count() == 1
+        assert a.count() == 1, a.count()
         c.dereference()
-        assert a.count() == 0, Reference.client.get(a.reflist_key)
+        assert a.count() == 0, a.nodelist.get_all_nodes()
 
         p.stop()
         p2.stop()
         p3.stop()
-
-    def test_remove_failed_processes(self):
-        now = datetime.datetime.now(pytz.utc)
-        expired = now - datetime.timedelta(seconds=2 * TTL + 1)
-        pids = {u'1': now.isoformat(),
-                u'2': expired.isoformat()}
-
-        p = Process()
-        a = p.create_reference('biz')
-
-        target = a.remove_failed_processes(pids)
-        assert u'2' not in target, target
-        assert u'1' in target, target
-        assert target[u'1'] == now.isoformat(), target
-
-        p.stop()
 
     def test_dereference_removes_pid_from_pids(self):
         p = Process()
@@ -408,14 +543,14 @@ class ReferenceTest(unittest.TestCase):
         p2 = Process()
         b = p2.create_reference('foo')
 
-        pids = json.loads(Process.client.get(a.reflist_key) or "{}")
+        pids = a.nodelist.get_all_nodes()
         assert a._Reference__process.id in pids
         assert b._Reference__process.id in pids
         a.dereference()
-        pids = json.loads(a._Reference__process.client.get(a.reflist_key) or "{}")
+        pids = a.nodelist.get_all_nodes()
         assert a._Reference__process.id not in pids
         b.dereference()
-        pids = json.loads(b._Reference__process.client.get(b.reflist_key) or "{}")
+        pids = a.nodelist.get_all_nodes()
         assert b._Reference__process.id not in pids
         assert len(pids) == 0
 
@@ -429,17 +564,17 @@ class ReferenceTest(unittest.TestCase):
         p2 = Process()
         b = p2.create_reference('foo')
 
-        pids = json.loads(Process.client.get(a.reflist_key) or "{}")
+        pids = a.nodelist.get_all_nodes()
         assert a._Reference__process.id in pids
         assert b._Reference__process.id in pids
         a.dereference()
-        pids = json.loads(a._Reference__process.client.get(a.reflist_key) or "{}")
+        pids = a.nodelist.get_all_nodes()
         assert a._Reference__process.id not in pids
         b.dereference()
-        pids = json.loads(b._Reference__process.client.get(b.reflist_key) or "{}")
+        pids = a.nodelist.get_all_nodes()
         assert b._Reference__process.id not in pids
         assert len(pids) == 0
-        assert Process.client.get(a.reflist_key) is None, Process.client.get(a.reflist_key)
+        assert a.nodelist.get_all_nodes() == {}, a.nodelist.get_all_nodes()
         assert Process.client.get(a.resource_key) is None, Process.client.get(a.resource_key)
         assert Process.client.get(a.times_modified_key) is None, Process.client.get(a.times_modified_key)
 
@@ -449,11 +584,11 @@ class ReferenceTest(unittest.TestCase):
     def test_dereference_handles_when_never_modified(self):
         p = Process()
         a = p.create_reference('foo')
-        pids = json.loads(a._Reference__process.client.get(a.reflist_key) or "{}")
+        pids = a.nodelist.get_all_nodes()
         assert len(pids) == 1, pids
 
         a.dereference()
-        pids = json.loads(a._Reference__process.client.get(a.reflist_key) or "{}")
+        pids = a.nodelist.get_all_nodes()
         assert len(pids) == 0, pids
 
         p.stop()
@@ -547,9 +682,9 @@ class UpdateTest(unittest.TestCase):
                        spec={'_id': 123}, doc={'a': 1., 'b': 2., 'c': 3.}, init_cache=False)
 
         client = a._Update__process.client
-        reflist = json.loads(client.get(a.ref.reflist_key) or "{}")
-        assert len(reflist) == 1
-        assert a._Update__process.id in reflist
+        nodelist = a.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 1
+        assert a._Update__process.id in nodelist
 
         p.stop()
 
@@ -699,11 +834,11 @@ class UpdateTest(unittest.TestCase):
                        spec={'_id': 123456}, doc={'a': 4., 'b': 5., 'c': 6.}, init_cache=True)
 
         assert a.ref.count() == 1, a.ref.count()
-        reflist = json.loads(client.get(a.ref.reflist_key) or "{}")
-        assert len(reflist) == 1
+        nodelist = a.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 1
         assert b.ref.count() == 1, b.ref.count()
-        reflist = json.loads(client.get(b.ref.reflist_key) or "{}")
-        assert len(reflist) == 1
+        nodelist = b.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 1
 
         assert a.ref.get_times_modified() == 2, a.ref.get_times_modified()
         a.force_expiry()
@@ -747,10 +882,10 @@ class UpdateTest(unittest.TestCase):
 
         assert a.ref.count() == 2, a.ref.count()
         assert b.ref.count() == 2, b.ref.count()
-        reflist = json.loads(client.get(a.ref.reflist_key) or "{}")
-        assert len(reflist) == 2
-        reflist = json.loads(client.get(b.ref.reflist_key) or "{}")
-        assert len(reflist) == 2
+        nodelist = a.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 2
+        nodelist = b.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 2
 
         assert a.ref.get_times_modified() == 1, a.ref.get_times_modified()
         a.force_expiry()
@@ -798,10 +933,10 @@ class UpdateTest(unittest.TestCase):
 
         assert a.ref.count() == 3, a.ref.count()
         assert b.ref.count() == 3, b.ref.count()
-        reflist = json.loads(client.get(a.ref.reflist_key) or "{}")
-        assert len(reflist) == 3
-        reflist = json.loads(client.get(b.ref.reflist_key) or "{}")
-        assert len(reflist) == 3
+        nodelist = a.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 3
+        nodelist = b.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 3
 
         b.cache()
         b.end_session()
@@ -872,10 +1007,10 @@ class UpdateTest(unittest.TestCase):
 
         assert a.ref.count() == 1, a.ref.count()
         assert b.ref.count() == 1, b.ref.count()
-        reflist = json.loads(client.get(a.ref.reflist_key) or "{}")
-        assert len(reflist) == 1
-        reflist = json.loads(client.get(b.ref.reflist_key) or "{}")
-        assert len(reflist) == 1
+        nodelist = a.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 1
+        nodelist = b.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 1
 
         b._Update__cache()
         assert a.ref.get_times_modified() == 1, a.ref.get_times_modified()
@@ -947,10 +1082,10 @@ class UpdateTest(unittest.TestCase):
 
         assert a.ref.count() == 2, a.ref.count()
         assert b.ref.count() == 2, b.ref.count()
-        reflist = json.loads(client.get(a.ref.reflist_key) or "{}")
-        assert len(reflist) == 2
-        reflist = json.loads(client.get(b.ref.reflist_key) or "{}")
-        assert len(reflist) == 2
+        nodelist = a.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 2
+        nodelist = b.ref.nodelist.get_all_nodes()
+        assert len(nodelist) == 2
 
         b._Update__cache()
         assert a.ref.get_times_modified() == 1, a.ref.get_times_modified()


### PR DESCRIPTION
Implements a Nodelist class using a hash in redis rather than a json object.  With this approach, we no longer need to lock on creation or update of the list and only when dereferencing or removing from the nodelist.