### PR TITLE
Add set_force_expiry method

### DIFF
--- a/phonon/update.py
+++ b/phonon/update.py
@@ -91,12 +91,22 @@ class BaseUpdate(object):
         return (current_time > self.hard_expiration or
                 current_time > self.soft_expiration)
 
+    def set_force_expiry(self, force_expire=True):
+        """
+        Updates the force_expiry setting on the Update's reference without
+        explicitly ending the session.
+
+        :param bool force_expire: Value to set force_expiry to.
+
+        """
+        self.ref.force_expiry = force_expire
+
     def force_expiry(self):
         """
         Expires current and cached references related to current Update object
         then ends the session.
         """
-        self.ref.force_expiry = True
+        self.set_force_expiry()
         self.end_session()
 
     def end_session(self, block=True):

--- a/test/update_test.py
+++ b/test/update_test.py
@@ -231,6 +231,21 @@ class UpdateTest(unittest.TestCase):
 
         p.stop()
 
+    def test_set_force_expiry(self):
+        p = Process()
+        a = UserUpdate(process=p, _id='123456', database='test', collection='user',
+                       spec={'_id': 123456}, doc={'a': 1., 'b': 2., 'c': 3.}, init_cache=True)
+
+        assert a.ref.force_expiry is False
+        a.set_force_expiry()
+        assert a.ref.force_expiry is True
+        a.set_force_expiry(False)
+        assert a.ref.force_expiry is False
+        a.set_force_expiry(True)
+        assert a.ref.force_expiry is True
+
+        p.stop()
+
     def test_force_expiry_init_cache(self):
         p = Process()
         client = p.client


### PR DESCRIPTION
Adds a `set_force_expiry` method on the Update, allowing a using to set the value on the ref without explicitly ending the Update's session at that moment.